### PR TITLE
Introduce outline

### DIFF
--- a/metamath-lsp/src/main.rs
+++ b/metamath-lsp/src/main.rs
@@ -3,6 +3,7 @@
 mod definition;
 mod diag;
 mod hover;
+mod outline;
 mod references;
 mod server;
 mod show_proof;
@@ -117,6 +118,22 @@ impl CondvarExt for std::sync::Condvar {
     }
 }
 
+// fn setup_log(debug: bool) {
+//     let level = if  {
+//         LevelFilter::Debug
+//     } else {
+//         LevelFilter::Info
+//     };
+//     use {
+//         simplelog::{Config, WriteLogger},
+//         std::fs::File,
+//     };
+//     std::env::set_var("RUST_BACKTRACE", "1");
+//     if let Ok(f) = File::create("lsp.log") {
+//         let _ = WriteLogger::init(level, Config::default(), f);
+//     }
+// }
+
 /// Main entry point for the Metamath language server.
 ///
 /// This function sets up an [LSP] connection using stdin and stdout.
@@ -157,19 +174,7 @@ pub fn main() {
                 .validator(positive_integer),
         )
         .get_matches();
-    let level = if matches.is_present("debug") {
-        LevelFilter::Debug
-    } else {
-        LevelFilter::Info
-    };
-    use {
-        simplelog::{Config, WriteLogger},
-        std::fs::File,
-    };
-    std::env::set_var("RUST_BACKTRACE", "1");
-    if let Ok(f) = File::create("lsp.log") {
-        let _ = WriteLogger::init(level, Config::default(), f);
-    }
+    // setup_log(matches.is_present("debug"));
     let db_file_name = matches.value_of("database").unwrap_or("None");
     let job_count = usize::from_str(matches.value_of("jobs").unwrap_or("1"))
         .expect("validator should check this");

--- a/metamath-lsp/src/outline.rs
+++ b/metamath-lsp/src/outline.rs
@@ -1,0 +1,69 @@
+//! Provides the database outline : chapters and sections
+
+// use crate::definition::stmt_range;
+use crate::vfs::Vfs;
+use crate::ServerError;
+use lsp_types::*;
+use metamath_knife::outline::OutlineNodeRef;
+use metamath_knife::parser::HeadingLevel;
+use metamath_knife::Database;
+
+#[allow(deprecated)] // workaround rust#60681 - ironically, the field "deprecated" is deprecated.
+/// Returns the LSP document symbol for a given outline
+fn document_symbol(
+    node: OutlineNodeRef,
+    include_statements: bool,
+    _vfs: &Vfs,
+    _db: &Database,
+) -> Option<DocumentSymbol> {
+    // let stmt = match node {
+    //     OutlineNodeRef::Chapter { node_id, .. } => {
+    //         let sadd = db.outline_result().tree.get(node_id).stmt_address;
+    //         db.statement_by_address(sadd)
+    //     },
+    //     OutlineNodeRef::Statement { sref, .. } => sref
+    // };
+    // let range = stmt_range(stmt, vfs, db)?;
+    let range = Range::new(Position::new(0, 0), Position::new(0, 0));
+    Some(DocumentSymbol {
+        name: node.get_name().to_string(),
+        detail: None,
+        kind: match node.get_level() {
+            HeadingLevel::Database => SymbolKind::FILE,
+            HeadingLevel::MajorPart => SymbolKind::MODULE,
+            HeadingLevel::Section => SymbolKind::NAMESPACE,
+            HeadingLevel::SubSection => SymbolKind::PACKAGE,
+            HeadingLevel::SubSubSection => SymbolKind::CLASS,
+            HeadingLevel::Statement => SymbolKind::METHOD,
+        },
+        tags: None,
+        deprecated: None,
+        range,
+        selection_range: range,
+        children: Some(children_symbols(node, include_statements, _vfs, _db)),
+    })
+}
+
+/// Returns a list of all children nodes of `node`, as LSP `DocumentSymbol`
+fn children_symbols(
+    node: OutlineNodeRef,
+    include_statements: bool,
+    vfs: &Vfs,
+    db: &Database,
+) -> Vec<DocumentSymbol> {
+    let mut chapters = vec![];
+    for chapter in node.children_iter() {
+        if include_statements || chapter.get_level() != HeadingLevel::Statement {
+            if let Some(symbol) = document_symbol(chapter, include_statements, vfs, db) {
+                chapters.push(symbol);
+            }
+        }
+    }
+    chapters
+}
+
+/// Builds the Outline
+pub(crate) fn outline(vfs: &Vfs, db: &Database) -> Result<Vec<DocumentSymbol>, ServerError> {
+    let root = OutlineNodeRef::root_node(db);
+    Ok(children_symbols(root, false, vfs, db))
+}

--- a/metamath-lsp/src/references.rs
+++ b/metamath-lsp/src/references.rs
@@ -1,7 +1,7 @@
 //! Provides references to a given statement
 
 use crate::definition::find_statement;
-use crate::definition::stmt_range;
+use crate::definition::stmt_location;
 use crate::server::word_at;
 use crate::util::FileRef;
 use crate::vfs::Vfs;
@@ -26,7 +26,7 @@ pub(crate) fn references(
         for stmt in db.statements_range_address((Bound::Excluded(stmt.address()), Bound::Unbounded))
         {
             if is_direct_use(&stmt, label) {
-                if let Some(location) = stmt_range(stmt, vfs, &db) {
+                if let Some(location) = stmt_location(stmt, vfs, &db) {
                     locations.push(location);
                 }
             }


### PR DESCRIPTION
This introduces a basic outline functionality.

However since `metamath-knife` does not provide the spans corresponding to outline chapters yet, chapters are not sorted correctly and the "Follow Cursor" functionality does not work.