### PR TITLE
Migration to Xi rope

### DIFF
--- a/metamath-lsp/Cargo.toml
+++ b/metamath-lsp/Cargo.toml
@@ -17,7 +17,7 @@ metamath-knife = { git = "https://github.com/david-a-wheeler/metamath-knife", ta
 lsp-server = "0.5"
 lsp-types = "0.92"
 lsp-text = "0.3"
-ropey = "1.2"
+xi-rope = "0.3"
 crossbeam = "0.8"
 futures = { version = "0.3", features = ["thread-pool"] }
 annotate-snippets = "0.9"
@@ -27,7 +27,7 @@ serde_json = "1.0"
 serde_repr = "0.1"
 pathdiff = "0.2"
 lazy_static = "1.4"
-simplelog = "0.11"
+# simplelog = "0.11"
 log = "0.4"
 
 [[bin]]

--- a/metamath-lsp/src/definition.rs
+++ b/metamath-lsp/src/definition.rs
@@ -1,10 +1,10 @@
 //! Provides hover information
 
+use crate::rope_ext::RopeExt;
 use crate::server::word_at;
 use crate::util::FileRef;
 use crate::vfs::Vfs;
 use crate::ServerError;
-use lsp_text::RopeExt;
 use lsp_types::*;
 use metamath_knife::Database;
 use metamath_knife::Span;

--- a/metamath-lsp/src/main.rs
+++ b/metamath-lsp/src/main.rs
@@ -5,6 +5,7 @@ mod diag;
 mod hover;
 mod outline;
 mod references;
+mod rope_ext;
 mod server;
 mod show_proof;
 mod util;

--- a/metamath-lsp/src/rope_ext.rs
+++ b/metamath-lsp/src/rope_ext.rs
@@ -1,0 +1,159 @@
+//! A collection of utilities for ropes.
+//! Takes care of reading Xi Ropes from files, adapting byte indices to LSP text positions, and providing lines
+use lsp_types::*;
+use std::borrow::Cow;
+use std::io::Error as IoError;
+use std::io::ErrorKind;
+use xi_rope::engine::Error;
+use xi_rope::tree::TreeBuilder;
+use xi_rope::Cursor;
+use xi_rope::Interval;
+use xi_rope::Rope;
+use xi_rope::RopeDelta;
+use xi_rope::RopeInfo;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct TextPosition {
+    pub char: u32,
+    pub byte: u32,
+    pub code: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TextEdit<'a> {
+    pub start_char_idx: usize,
+    pub end_char_idx: usize,
+    pub text: &'a str,
+}
+
+pub trait RopeExt {
+    fn from_reader<T: std::io::Read>(reader: T) -> Result<Self, IoError>
+    where
+        Self: Sized;
+    fn change_event_to_rope_delta(
+        &self,
+        change: &TextDocumentContentChangeEvent,
+    ) -> Result<RopeDelta, Error>;
+    fn byte_to_lsp_position(&self, offset: usize) -> Position;
+    fn lsp_position_to_byte(&self, position: Position) -> usize;
+    fn cursor_to_lsp_position(&self, cursor: Cursor<RopeInfo>) -> Result<Position, Error>;
+    fn lsp_position_to_cursor(&self, position: Position) -> Result<Cursor<RopeInfo>, Error>;
+    fn line(&self, line_idx: u32) -> Cow<str>;
+}
+
+impl RopeExt for Rope {
+    fn from_reader<T: std::io::Read>(mut reader: T) -> Result<Self, IoError>
+    where
+        Self: Sized,
+    {
+        // Note: this method is based on Ropey's `from_reader`, adapted to Xi ropes
+        const BUFFER_SIZE: usize = 4096;
+        let mut builder = TreeBuilder::new();
+        let mut buffer = [0u8; BUFFER_SIZE];
+        let mut fill_idx = 0; // How much `buffer` is currently filled with valid data
+        loop {
+            match reader.read(&mut buffer[fill_idx..]) {
+                Ok(read_count) => {
+                    fill_idx += read_count;
+
+                    // Determine how much of the buffer is valid utf8.
+                    let valid_count = match std::str::from_utf8(&buffer[..fill_idx]) {
+                        Ok(_) => fill_idx,
+                        Err(e) => e.valid_up_to(),
+                    };
+
+                    // Append the valid part of the buffer to the rope.
+                    if valid_count > 0 {
+                        builder.push_str(
+                            std::str::from_utf8(&buffer[..valid_count])
+                                .map_err(|e| IoError::new(ErrorKind::InvalidData, e))?,
+                        );
+                    }
+
+                    // Shift the un-read part of the buffer to the beginning.
+                    if valid_count < fill_idx {
+                        buffer.copy_within(valid_count..fill_idx, 0);
+                    }
+                    fill_idx -= valid_count;
+
+                    if fill_idx == BUFFER_SIZE {
+                        // Buffer is full and none of it could be consumed.  Utf8
+                        // codepoints don't get that large, so it's clearly not
+                        // valid text.
+                        return Err(IoError::new(
+                            ErrorKind::InvalidData,
+                            "stream did not contain valid UTF-8",
+                        ));
+                    }
+
+                    // If we're done reading
+                    if read_count == 0 {
+                        if fill_idx > 0 {
+                            // We couldn't consume all data.
+                            return Err(IoError::new(
+                                ErrorKind::InvalidData,
+                                "stream contained invalid UTF-8",
+                            ));
+                        } else {
+                            return Ok(builder.build());
+                        }
+                    }
+                }
+
+                Err(e) => {
+                    // Read error
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    fn change_event_to_rope_delta(
+        &self,
+        change: &TextDocumentContentChangeEvent,
+    ) -> Result<RopeDelta, Error> {
+        let text = change.text.as_str();
+        let text_bytes = text.as_bytes();
+        let text_end_byte_idx = text_bytes.len();
+
+        let interval = if let Some(range) = change.range {
+            Interval::new(
+                self.lsp_position_to_byte(range.start),
+                self.lsp_position_to_byte(range.end),
+            )
+        } else {
+            Interval::new(0, text_end_byte_idx)
+        };
+
+        let new_text = Rope::from(text);
+        Ok(RopeDelta::simple_edit(interval, new_text, text.len()))
+    }
+
+    fn byte_to_lsp_position(&self, byte_idx: usize) -> Position {
+        let line_idx = self.line_of_offset(byte_idx);
+        let start_line_idx = self.offset_of_line(line_idx);
+        Position::new(line_idx as u32, (byte_idx - start_line_idx) as u32)
+    }
+
+    fn lsp_position_to_byte(&self, position: Position) -> usize {
+        let start_line_idx = self.offset_of_line(position.line as usize);
+        start_line_idx + position.character as usize
+    }
+
+    fn cursor_to_lsp_position(
+        &self,
+        _cursor: xi_rope::Cursor<RopeInfo>,
+    ) -> std::result::Result<lsp_types::Position, xi_rope::engine::Error> {
+        todo!()
+    }
+
+    fn lsp_position_to_cursor(&self, _position: Position) -> Result<Cursor<RopeInfo>, Error> {
+        todo!()
+    }
+
+    fn line(&self, line_idx: u32) -> Cow<str> {
+        let start_byte_idx = self.offset_of_line(line_idx as usize);
+        let end_byte_idx = self.offset_of_line((line_idx + 1) as usize as usize);
+        self.slice_to_cow(start_byte_idx..end_byte_idx)
+    }
+}

--- a/metamath-lsp/src/server.rs
+++ b/metamath-lsp/src/server.rs
@@ -6,6 +6,7 @@ use crate::diag::make_lsp_diagnostic;
 use crate::hover::hover;
 use crate::outline::outline;
 use crate::references::references;
+use crate::rope_ext::RopeExt;
 use crate::show_proof::show_proof;
 use crate::vfs::FileContents;
 use crate::vfs::Vfs;
@@ -98,12 +99,9 @@ fn is_label_char(c: char) -> bool {
 
 /// Attempts to find a word around the given position
 pub fn word_at(pos: Position, source: FileContents) -> (String, Range) {
-    let line = source
-        .text
-        .get_line(pos.line as usize)
-        .unwrap_or_else(|| source.text.slice(0..0));
+    let line = source.text.line(pos.line);
     let mut start = 0;
-    let mut end = line.len_chars() as u32;
+    let mut end = line.len() as u32;
     for (idx, ch) in line.chars().enumerate() {
         if !is_token_char(ch) {
             if idx < pos.character as usize {
@@ -115,9 +113,7 @@ pub fn word_at(pos: Position, source: FileContents) -> (String, Range) {
         }
     }
     (
-        line.get_slice(start as usize..end as usize)
-            .unwrap()
-            .to_string(),
+        line[start as usize..end as usize].to_string(),
         Range::new(Position::new(pos.line, start), Position::new(pos.line, end)),
     )
 }

--- a/metamath-lsp/src/vfs.rs
+++ b/metamath-lsp/src/vfs.rs
@@ -1,14 +1,15 @@
 //! Virtual File System
 //! Keeps track of the files opened, and their current in-memory state
 
+use crate::rope_ext::RopeExt;
 use crate::util::FileRef;
 use crate::MutexExt;
 //use metamath_mmp::ProofWorksheet;
-use ropey::Rope;
 use std::collections::{hash_map::Entry, HashMap};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::{fs, io};
+use xi_rope::Rope;
 
 #[derive(Clone)]
 pub struct FileContents {
@@ -33,7 +34,7 @@ pub struct VirtualFile {
 impl VirtualFile {
     fn from_path(version: Option<i32>, path: PathBuf) -> io::Result<VirtualFile> {
         let file = fs::File::open(path)?;
-        let text = Rope::from_reader(file)?;
+        let text = RopeExt::from_reader(file)?;
         Ok(VirtualFile {
             text: Mutex::new((version, FileContents::new(text))),
         })


### PR DESCRIPTION
I plan to use Xi ropes for MMP files, because they allow storing information alongside the basic line number / UTF char numbers, so this migrates to using Xi ropes.